### PR TITLE
Lifecycle flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,25 @@ await User.query().upsertGraph({
 }); // => phone id 6 will be flagged deleted (and will still be related to Johnny!), email id 3 will be removed from the database
 ```
 
+### Lifecycle Functions
+
+One issue that comes with doing soft deletes is that your calls to `.delete()` will actually trigger lifecycle functions for `.update()`, which may not be expected or desired.  To help address this, some context flags have been added to the `queryContext` that is passed into lifecycle functions to help discern whether the event that triggered (e.g.) `$beforeUpdate` was a true update, a soft delete, or an undelete:
+```js
+  $beforeUpdate(opt, queryContext) {
+    if (queryContext.softDelete) {
+      // do something before a soft delete, possibly including calling your $beforeDelete function.
+      // Think this through carefully if you are using additional plugins, as their lifecycle
+      // functions may execute before this one depending on how you have set up your inheritance chain!
+    } else if (queryContext.undelete) {
+      // do something before an undelete
+    } else {
+      // do something before a normal update
+    }
+  }
+  
+  // same procedure for $afterUpdate
+```
+
 ## Options
 
 **columnName:** the name of the column to use as the soft delete flag on the model (Default: `'deleted'`).  The column must exist on the table for the model.

--- a/README.md
+++ b/README.md
@@ -258,6 +258,11 @@ One issue that comes with doing soft deletes is that your calls to `.delete()` w
   
   // same procedure for $afterUpdate
 ```
+Available flags are:
+* softDelete
+* undelete
+
+Flags will be `true` if set, and `undefined` otherwise.
 
 ## Options
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ module.exports = (incomingOptions) => {
     class SDQueryBuilder extends Model.QueryBuilder {
       // override the normal delete function with one that patches the row's "deleted" column
       delete() {
+        this.mergeContext({
+          softDelete: true,
+        });
         const patch = {};
         patch[options.columnName] = true;
         return this.patch(patch);
@@ -21,6 +24,9 @@ module.exports = (incomingOptions) => {
 
       // provide a way to undo the delete
       undelete() {
+        this.mergeContext({
+          undelete: true,
+        });
         const patch = {};
         patch[options.columnName] = false;
         return this.patch(patch);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objection-soft-delete",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A plugin for objection js to support soft delete functionallity",
   "main": "index.js",
   "scripts": {

--- a/tests.js
+++ b/tests.js
@@ -8,24 +8,16 @@ const Knex = require('knex');
 // eslint-disable-next-line
 const expect = require('chai').expect;
 
-let beforeHardDelete;
-let afterHardDelete;
 let beforeSoftDelete;
 let afterSoftDelete;
 let beforeUndelete;
 let afterUndelete;
-let beforeUpdate;
-let afterUpdate;
 
 function resetLifecycleChecks() {
-  beforeHardDelete = false;
-  afterHardDelete = false;
   beforeSoftDelete = false;
   afterSoftDelete = false;
   beforeUndelete = false;
   afterUndelete = false;
-  beforeUpdate = false;
-  afterUpdate = false;
 }
 
 function getModel(options) {
@@ -38,12 +30,10 @@ function getModel(options) {
 
     $beforeDelete(queryContext) {
       super.$beforeDelete(queryContext);
-      beforeHardDelete = true;
     }
 
     $afterDelete(queryContext) {
       super.$afterDelete(queryContext);
-      afterHardDelete = true;
     }
 
     $beforeUpdate(opts, queryContext) {
@@ -52,8 +42,6 @@ function getModel(options) {
         beforeSoftDelete = true;
       } else if (queryContext.undelete) {
         beforeUndelete = true;
-      } else {
-        beforeUpdate = true;
       }
     }
 
@@ -63,8 +51,6 @@ function getModel(options) {
         afterSoftDelete = true;
       } else if (queryContext.undelete) {
         afterUndelete = true;
-      } else {
-        afterUpdate = true;
       }
     }
   };


### PR DESCRIPTION
This update adds flags to the `queryContext` that is passed to the lifecycle functions in the objection models in order to make it easier to determine whether a soft delete or a true update was called.