### PR TITLE
add indication of whether a class is softdelete or not

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = (incomingOptions) => {
         });
       }
 
-      static get softDelete() {
+      static get isSoftDelete() {
         return true;
       }
     };

--- a/index.js
+++ b/index.js
@@ -61,6 +61,10 @@ module.exports = (incomingOptions) => {
           },
         });
       }
+
+      static get softDelete() {
+        return true;
+      }
     };
   };
 };

--- a/tests.js
+++ b/tests.js
@@ -650,4 +650,11 @@ describe('Soft Delete plugin tests', () => {
         });
     });
   });
+
+  describe('soft delete indicator', () => {
+    it('should set isSoftDelete property', () => {
+      // eslint-disable-next-line no-unused-expressions
+      expect(getModel().isSoftDelete).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
I have a base class that everything else extends off of, and I often like to put some commonly used queries as base class method. But those queries need to be adjusted for models with soft-delete functionality, as I don't want deleted entries from showing up in search results, so I often have a hack like this in my base class:

```js
static get isSoftDelete() {
    return this.namedFilters && this.namedFilters.hasOwnProperty("deleted")
}
```

I mean, it _works_, but it's fugly and I think it'd be very nice to be able to tell if any particular model is uses soft deletion instead of hard deletion.